### PR TITLE
TypeError: this.config.devices is not iterable

### DIFF
--- a/src/switchbot-platform.ts
+++ b/src/switchbot-platform.ts
@@ -58,6 +58,7 @@ class SwitchBotPlatform implements StaticPlatformPlugin {
    */
   accessories(callback: (foundAccessories: AccessoryPlugin[]) => void): void {
     let deviceList = [];
+    if (this.config.devices) {
     for (var device of this.config.devices) {
       // this.log.info(device.type);
       // this.log.info(device.name);
@@ -84,6 +85,7 @@ class SwitchBotPlatform implements StaticPlatformPlugin {
           break;
       }
     }
+  }
     this.log("Device amount:", deviceList.length.toString());
     callback(deviceList);
   }

--- a/src/switchbot-platform.ts
+++ b/src/switchbot-platform.ts
@@ -85,6 +85,8 @@ class SwitchBotPlatform implements StaticPlatformPlugin {
           break;
       }
     }
+  } else {
+    this.log.error('No Device Set In Config')
   }
     this.log("Device amount:", deviceList.length.toString());
     callback(deviceList);


### PR DESCRIPTION
I was getting this error. This should fix this.

```
[12/9/2020, 12:48:39 PM] TypeError: this.config.devices is not iterable
    at SwitchBotPlatform.accessories (/usr/local/lib/node_modules/@switchbot/homebridge-switchbot-ble/src/switchbot-platform.ts:61:36)
    at /usr/local/lib/node_modules/homebridge/src/server.ts:418:24
    at new Promise (<anonymous>)
    at Server.loadPlatformAccessories (/usr/local/lib/node_modules/homebridge/src/server.ts:412:12)
    at /usr/local/lib/node_modules/homebridge/src/server.ts:400:28
    at Array.forEach (<anonymous>)
    at Server.loadPlatforms (/usr/local/lib/node_modules/homebridge/src/server.ts:372:27)
    at Server.start (/usr/local/lib/node_modules/homebridge/src/server.ts:151:29)
    at cli (/usr/local/lib/node_modules/homebridge/src/cli.ts:80:10)
    at Object.<anonymous> (/usr/local/lib/node_modules/homebridge/bin/homebridge:17:22)
```