### PR TITLE
Add retry support to address disconnects

### DIFF
--- a/src/bot-accessory.ts
+++ b/src/bot-accessory.ts
@@ -18,6 +18,7 @@ export class Bot implements AccessoryPlugin {
   private readonly log: Logging;
   private readonly bleMac: string;
   private readonly scanDuration: number;
+  private readonly switchbot: any;
 
   private switchOn = false;
   private runTimer!: NodeJS.Timeout;
@@ -33,6 +34,8 @@ export class Bot implements AccessoryPlugin {
     this.name = name;
     this.bleMac = bleMac;
     this.scanDuration = scanDuration;
+    const SwitchBot = require("node-switchbot");
+    this.switchbot = new SwitchBot();
 
     this.botService = new hap.Service.Switch(name);
     this.botService
@@ -51,10 +54,8 @@ export class Bot implements AccessoryPlugin {
         }
         // Target state has been changed.
         log.info("Target state of Bot setting: " + (targetState ? "ON" : "OFF"));
-        const SwitchBot = require("node-switchbot");
-        const switchbot = new SwitchBot();
-        switchbot
-          .discover({ duration: this.scanDuration, model: "H", quick: false })
+        this.switchbot
+          .discover({ duration: this.scanDuration, model: "H", quick: true, id: this.bleMac })
           .then((device_list: any) => {
             log.info("Scan done.");
             let targetDevice: any = null;
@@ -66,9 +67,9 @@ export class Bot implements AccessoryPlugin {
               }
             }
             if (!targetDevice) {
-              log.info("No device was found.");
+              log.info("No device was found during scan.");
               return new Promise((resolve, reject) => {
-                reject(new Error("No device was found."));
+                reject(new Error("No device was found during scan."));
               });
             } else {
               log.info(targetDevice.modelName + " (" + targetDevice.address + ") was found.");
@@ -80,11 +81,7 @@ export class Bot implements AccessoryPlugin {
                 // log.info('Disconnected.');
               };
               log.info("Bot is running...");
-              if (targetState) {
-                return targetDevice.turnOn();
-              } else {
-                return targetDevice.turnOff();
-              }
+              return this.setTargetDeviceState(targetDevice, targetState);
             }
           })
           .then(() => {
@@ -112,6 +109,28 @@ export class Bot implements AccessoryPlugin {
       .setCharacteristic(hap.Characteristic.SerialNumber, this.bleMac);
 
     log.info("Bot '%s' created!", name);
+  }
+
+  async retry(max: number, fn: Function): Promise<null> {
+    return fn().catch( async (err: any) => {
+      if (max == 0) {
+        throw err;
+      }
+      this.log.info(err);
+      this.log.info("Retrying");
+      await this.switchbot.wait(1000);
+      return this.retry(max - 1, fn);
+    });
+  }
+
+  async setTargetDeviceState(targetDevice: any, targetState: boolean): Promise<null> {
+    return await this.retry(5, () => {
+      if (targetState) {
+        return targetDevice.turnOn();
+      } else {
+        return targetDevice.turnOff();
+      }
+    });
   }
 
   /*


### PR DESCRIPTION
I started seeing issue #52 when I moved my pi further away from my switchbot.

This PR adds a retry loop if the switch action fails.

It also speeds up scanning by telling the underlying library to return as soon as it finds the device we are looking for.

An example run of turning it on and off and the off failing and retrying

```
[6/29/2021, 10:17:41 PM] [SwitchBotPlatform] Current state of Bot was returned: OFF
[6/29/2021, 10:17:44 PM] [SwitchBotPlatform] Target state of Bot setting: ON
[6/29/2021, 10:17:44 PM] [SwitchBotPlatform] Scan done.
[6/29/2021, 10:17:44 PM] [SwitchBotPlatform] WoHand (ca:05:af:db:0c:da) was found.
[6/29/2021, 10:17:44 PM] [SwitchBotPlatform] Bot is running...
[6/29/2021, 10:17:46 PM] [SwitchBotPlatform] Done.
[6/29/2021, 10:17:46 PM] [SwitchBotPlatform] Bot state has been set to: ON
[6/29/2021, 10:17:51 PM] [SwitchBotPlatform] Target state of Bot setting: OFF
[6/29/2021, 10:17:51 PM] [SwitchBotPlatform] Scan done.
[6/29/2021, 10:17:51 PM] [SwitchBotPlatform] WoHand (ca:05:af:db:0c:da) was found.
[6/29/2021, 10:17:51 PM] [SwitchBotPlatform] Bot is running...
[6/29/2021, 10:17:52 PM] [SwitchBotPlatform] Error: Failed to discover services and characteristics: DISCONNECTED
    at SwitchbotDeviceWoHand._ondisconnect_internal (/home/pi/homebridge-switchbot-ble/node_modules/node-switchbot/lib/switchbot-device.js:161:16)
    at Peripheral.<anonymous> (/home/pi/homebridge-switchbot-ble/node_modules/node-switchbot/lib/switchbot-device.js:122:14)
    at Object.onceWrapper (events.js:421:28)
    at Peripheral.emit (events.js:315:20)
    at Noble.onDisconnect (/home/pi/homebridge-switchbot-ble/node_modules/@abandonware/noble/lib/noble.js:228:16)
    at NobleBindings.emit (events.js:315:20)
    at NobleBindings.onDisconnComplete (/home/pi/homebridge-switchbot-ble/node_modules/@abandonware/noble/lib/hci-socket/bindings.js:264:10)
    at Hci.emit (events.js:315:20)
    at Hci.onSocketData (/home/pi/homebridge-switchbot-ble/node_modules/@abandonware/noble/lib/hci-socket/hci.js:549:12)
    at BluetoothHciSocket.emit (events.js:315:20)
[6/29/2021, 10:17:52 PM] [SwitchBotPlatform] Retrying
[6/29/2021, 10:17:53 PM] [SwitchBotPlatform] Done.
[6/29/2021, 10:17:53 PM] [SwitchBotPlatform] Bot state has been set to: OFF
```