### PR TITLE
set current position to actual device position

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,12 @@ If it work, add devices.
 
 **Optional Settings**
 
-- `scanDuration` - Scan timeout. BLE Central must first scan the advertising. Default is `1000`(unit: ms). Longer time to ensure device discovery but slower response.
+- `scanDuration` - Scan timeout. BLE Central must first scan the advertising. Default is `1000` (unit: ms). Longer time to ensure device discovery but slower response.
 - `reverseDir` - Set to `true` to exchange the "opened" and "closed" directions of Curtain after calibration. Default is `false`. So you can swap the directions without recalibration.
-- `moveTime` - Set the actual running time of Curtian, which is also the time to switch from running state to opened/closeed state in the Home APP. Default is `2000`(unit: ms).
-- `scanInterval` - Scan interval. Currently indicates the cycle of updating the temperature and humidity value of Meter. Default is `60000`(unit: ms).
+- `moveTime` - Set the actual running time of Curtain, which is also the time to switch from running state to opened/closed state in the Home APP. Default is `2000` (unit: ms).
+- `scanInterval`
+  - For a Meter, sets how frequently to scan in order to retrieve temperature and humidity values. Default is `60000` (unit: ms).
+  - For a Curtain, sets how frequently to scan in order to retrieve the curtain position. Default is `60000` (unit: ms) when idle.
 
 Please note that:
 

--- a/src/curtain-accessory.ts
+++ b/src/curtain-accessory.ts
@@ -10,9 +10,162 @@ import {
   HAP,
   Logging,
   Service,
-  CharacteristicEventTypes,
+  CharacteristicEventTypes, Characteristic,
 } from "homebridge";
-import { rejects } from "assert";
+
+type OnPositionReceived = (pos: number) => void
+
+class Device {
+  private readonly bleMac: string;
+  private readonly scanDuration: number;
+  private readonly slowScanInterval: number;
+  private readonly fastScanInterval = 500;
+  private readonly fastScanDuration = 10000;
+
+  private readonly name: string;
+  private readonly log: Logging;
+  private readonly callback: OnPositionReceived;
+  private readonly considerClosedAtPosition = 98;
+
+  private fastScanEnabled = false;
+  private autoDisableFastScanTimeoutId: NodeJS.Timeout | null = null;
+
+  private scanIntervalId: NodeJS.Timeout | null = null;
+
+  private previousPosition = -1;
+  private position = -1;
+
+  constructor(bleMac: string, name: string, log: Logging, scanDuration: number, scanInterval: number, callback: OnPositionReceived) {
+    this.name = name;
+    this.bleMac = bleMac;
+    this.log = log;
+
+    this.scanDuration = scanDuration;
+    this.slowScanInterval = scanInterval;
+    this.callback = callback;
+
+    this.startFastScan();
+  }
+
+  /**
+   * Ask the device to start moving to the given position (which must be a device value and not an HomeKit value).
+   * Returns a Promise that's resolved as soon as the command was sent to the device.
+   */
+  public runToPosition(pos: number): Promise<void> {
+    const SwitchBot = require("node-switchbot");
+    const switchbot = new SwitchBot();
+
+    return switchbot
+      .discover({duration: this.scanDuration, model: "c", quick: false})
+      .then((device_list: any) => {
+        let targetDevice: any = null;
+
+        for (let device of device_list) {
+          this.log.info(device.modelName, device.address);
+          if (device.address == this.bleMac) {
+            targetDevice = device;
+            break;
+          }
+        }
+
+        if (!targetDevice) {
+          return new Promise((resolve, reject) => {
+            reject(new Error("Curtain '" + this.name + "' (" + this.bleMac + "): device not found."));
+          });
+        }
+
+        this.startFastScan();
+
+        this.log.info("Curtain '%s' (%s) is moving to %d%%...", this.name, this.bleMac, pos);
+        return targetDevice.runToPos(pos);
+      });
+  }
+
+  /**
+   * Start a faster scan loop (using fastScanInterval). Used in calls to `runToPosition` to
+   * report quicker on device position change. Will disable on its own as soon if the curtain's
+   * device position does not change for more than `fastScanDuration`.
+   */
+  private startFastScan() {
+    if (this.fastScanEnabled) {
+      return;
+    }
+    this.fastScanEnabled = true;
+    this.startScanLoop();
+  }
+
+  private stopFastScan() {
+    if (!this.fastScanEnabled) {
+      return;
+    }
+    this.fastScanEnabled = false;
+    this.startScanLoop();
+  }
+
+  private get scanInterval(): number {
+    return this.fastScanEnabled ? this.fastScanInterval : this.slowScanInterval;
+  }
+
+  private startScanLoop() {
+    if (this.scanIntervalId !== null) {
+      clearInterval(this.scanIntervalId);
+    }
+
+    this.log.info("Curtain '%s': starting scan loop with interval %d", this.name, this.scanInterval);
+
+    this.scanIntervalId = setInterval(() => {
+      this.scan().catch((err) => {
+        this.log.error("error while scanning for Curtain '%s': %s", this.name, err);
+      });
+    }, this.scanInterval);
+  }
+
+  private scan(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const SwitchBot = require("node-switchbot");
+      const switchbot = new SwitchBot();
+      switchbot.onadvertisement = (ad: any) => {
+        this.applyPosition(ad);
+      };
+      switchbot.startScan({id: this.bleMac})
+        .then(() => {
+          return switchbot.wait(this.scanDuration);
+        })
+        .then(() => {
+          resolve();
+          switchbot.stopScan();
+        })
+        .catch((err: any) => {
+          reject(err);
+        });
+    });
+  }
+
+  private applyPosition(ad: any) {
+    let pos = ad.serviceData.position;
+
+    if (pos >= this.considerClosedAtPosition) {
+      pos = 100;
+    }
+
+    this.previousPosition = this.position;
+    this.position = pos;
+
+    if (this.position === this.previousPosition) {
+      return;
+    }
+
+    if (this.autoDisableFastScanTimeoutId !== null) {
+      clearTimeout(this.autoDisableFastScanTimeoutId);
+    }
+
+    this.autoDisableFastScanTimeoutId = setTimeout(() => {
+      this.stopFastScan();
+    }, this.fastScanDuration);
+
+    this.callback(this.position);
+  }
+}
 
 export class Curtain implements AccessoryPlugin {
   private readonly log: Logging;
@@ -20,6 +173,8 @@ export class Curtain implements AccessoryPlugin {
   private readonly scanDuration: number;
   private readonly reverseDir: boolean;
   private readonly moveTime: number;
+
+  private didReceiveInitialPosition = false;
 
   private currentPosition = 0;
   private targetPosition = 0;
@@ -32,7 +187,13 @@ export class Curtain implements AccessoryPlugin {
   private readonly curtainService: Service;
   private readonly informationService: Service;
 
-  constructor(hap: HAP, log: Logging, name: string, bleMac: string, scanDuration: number, reverseDir: boolean, moveTime: number) {
+  private device: Device;
+
+  private currentPositionCharacteristic: Characteristic;
+  private targetPositionCharacteristic: Characteristic;
+  private positionStateCharacteristic: Characteristic;
+
+  constructor(hap: HAP, log: Logging, name: string, bleMac: string, scanDuration: number, reverseDir: boolean, moveTime: number, scanInterval: number) {
     this.log = log;
     this.name = name;
     this.bleMac = bleMac;
@@ -40,18 +201,45 @@ export class Curtain implements AccessoryPlugin {
     this.reverseDir = reverseDir;
     this.moveTime = moveTime;
 
-    this.positionState = hap.Characteristic.PositionState.STOPPED;
+    this.device = new Device(bleMac, name, log, scanDuration, scanInterval, (pos: number) => {
+      this.currentPosition = this.convertFromHomeKitPosition(pos);
+      this.currentPositionCharacteristic.updateValue(this.currentPosition);
 
+      // Set target to the same value as current on the first received position, or if the curtain is in
+      // STOPPED state (eg. it's still or not moving from a change triggered by HomeKit). Otherwise, with
+      // target = X and current != X, HomeKit will assume curtain is moving and show the progress indicator.
+      //
+      // Note that on an HomeKit-triggered change, `positionState` is set to STOPPED after `moveTime` has
+      // passed, rather than when the curtain actually finished moving. When `moveTime` is lower than the
+      // curtain's actual travel time, the device will appear in HomeKit first as moving (with a progress
+      // indicator) then after `moveTime` has passed, as not moving (without progress indicator), but with
+      // rapidly changing percentages.
+      if (!this.didReceiveInitialPosition || this.positionState === hap.Characteristic.PositionState.STOPPED) {
+        this.didReceiveInitialPosition = true;
+        this.targetPosition = this.currentPosition;
+        this.targetPositionCharacteristic.updateValue(this.targetPosition);
+      }
+    });
+
+    this.positionState = hap.Characteristic.PositionState.STOPPED;
     this.curtainService = new hap.Service.WindowCovering(name);
-    this.curtainService
-      .getCharacteristic(hap.Characteristic.CurrentPosition)
+
+    this.currentPositionCharacteristic = this.curtainService
+      .getCharacteristic(hap.Characteristic.CurrentPosition);
+
+    this.targetPositionCharacteristic = this.curtainService
+      .getCharacteristic(hap.Characteristic.TargetPosition);
+
+    this.positionStateCharacteristic = this.curtainService
+      .getCharacteristic(hap.Characteristic.PositionState);
+
+    this.currentPositionCharacteristic
       .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
         log.info("Current position of Curtain was returned: " + this.currentPosition + "%");
         callback(undefined, this.currentPosition);
       });
 
-    this.curtainService
-      .getCharacteristic(hap.Characteristic.TargetPosition)
+    this.targetPositionCharacteristic
       .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
         log.info("Target position of Curtain was returned: " + this.targetPosition + "%");
         callback(undefined, this.targetPosition);
@@ -69,64 +257,21 @@ export class Curtain implements AccessoryPlugin {
         }
 
         if (this.positionState === hap.Characteristic.PositionState.STOPPED) {
-          this.curtainService?.getCharacteristic(hap.Characteristic.TargetPosition).updateValue(this.targetPosition);
-          this.curtainService?.getCharacteristic(hap.Characteristic.CurrentPosition).updateValue(this.currentPosition);
-          this.curtainService?.getCharacteristic(hap.Characteristic.PositionState).updateValue(this.positionState);
+          this.targetPositionCharacteristic.updateValue(this.targetPosition);
+          this.currentPositionCharacteristic.updateValue(this.currentPosition);
+          this.positionStateCharacteristic.updateValue(this.positionState);
           callback();
         } else {
-          const SwitchBot = require("node-switchbot");
-          const switchbot = new SwitchBot();
-          switchbot
-            .discover({ duration: this.scanDuration, model: "c", quick: false })
-            .then((device_list: any) => {
-              log.info("Scan done.");
-              let targetDevice: any = null;
-              for (let device of device_list) {
-                log.info(device.modelName, device.address);
-                if (device.address == this.bleMac) {
-                  targetDevice = device;
-                  break;
-                }
-              }
-              if (!targetDevice) {
-                log.info(name + " (" + bleMac + ") was not found.");
-                return new Promise((resolve, reject) => {
-                  reject(new Error("No target device was found."));
-                });
-              } else {
-                log.info(targetDevice.modelName + " (" + targetDevice.address + ") was found.");
-                // Set event handers
-                targetDevice.onconnect = () => {
-                  // log.info('Connected.');
-                };
-                targetDevice.ondisconnect = () => {
-                  // log.info('Disconnected.');
-                };
-                log.info("Curtain is moving...");
-                /**opend - 0% in HomeKit, 100% in Curtain device.
-                 * closed - 100% in HomeKit, 0% in Curtain device.
-                 * To keep the status synchronized, convert the percentage of homekit to the percentage of Curtain.
-                 */
-                let covertToDevicePosition = 0;
-                if (!reverseDir) {
-                  covertToDevicePosition = 100 - this.targetPosition;
-                } else {
-                  log.info('Reverse the "opened" and "closed" directions!');
-                  covertToDevicePosition = this.targetPosition;
-                }
-                return targetDevice.runToPos(covertToDevicePosition);
-              }
-            })
+          this.device.runToPosition(this.convertFromHomeKitPosition(this.targetPosition))
             .then(() => {
               log.info("Done.");
               log.info("Target position of Curtain has been set to: " + this.targetPosition + "%");
               this.moveTimer = setTimeout(() => {
                 // log.info("setTimeout", this.positionState.toString(), this.currentPosition.toString(), this.targetPosition.toString());
-                this.currentPosition = this.targetPosition;
                 this.positionState = hap.Characteristic.PositionState.STOPPED;
                 // this.curtainService?.getCharacteristic(hap.Characteristic.TargetPosition).updateValue(this.targetPosition);
-                this.curtainService?.getCharacteristic(hap.Characteristic.CurrentPosition).updateValue(this.currentPosition);
-                this.curtainService?.getCharacteristic(hap.Characteristic.PositionState).updateValue(this.positionState);
+                this.currentPositionCharacteristic.updateValue(this.currentPosition);
+                this.positionStateCharacteristic.updateValue(this.positionState);
               }, this.moveTime);
               callback();
             })
@@ -135,9 +280,9 @@ export class Curtain implements AccessoryPlugin {
               this.moveTimer = setTimeout(() => {
                 this.targetPosition = this.currentPosition;
                 this.positionState = hap.Characteristic.PositionState.STOPPED;
-                this.curtainService?.getCharacteristic(hap.Characteristic.TargetPosition).updateValue(this.targetPosition);
+                this.targetPositionCharacteristic.updateValue(this.targetPosition);
                 // this.curtainService?.getCharacteristic(hap.Characteristic.CurrentPosition).updateValue(this.currentPosition);
-                this.curtainService?.getCharacteristic(hap.Characteristic.PositionState).updateValue(this.positionState);
+                this.positionStateCharacteristic.updateValue(this.positionState);
               }, 1000);
               log.info("Target position of Curtain failed to be set to: " + this.targetPosition + "%");
               callback();
@@ -145,8 +290,7 @@ export class Curtain implements AccessoryPlugin {
         }
       });
 
-    this.curtainService
-      .getCharacteristic(hap.Characteristic.PositionState)
+    this.positionStateCharacteristic
       .on(CharacteristicEventTypes.GET, (callback: CharacteristicGetCallback) => {
         log.info("The position state of Curtain was returned: " + this.positionState);
         callback(undefined, this.positionState);
@@ -158,6 +302,23 @@ export class Curtain implements AccessoryPlugin {
       .setCharacteristic(hap.Characteristic.SerialNumber, this.bleMac);
 
     log.info("Curtain '%s' created!", name);
+  }
+
+
+  /**
+   * Convert to/from device/HomeKit's position, since:
+   *
+   * - opened is 0% in HomeKit and 100% in Curtain device.
+   * - closed is 100% in HomeKit, 0% in Curtain device.
+   */
+  convertFromHomeKitPosition(n: number): number {
+    let covertToDevicePosition: number;
+    if (this.reverseDir) {
+      covertToDevicePosition = n;
+    } else {
+      covertToDevicePosition = 100 - n;
+    }
+    return covertToDevicePosition;
   }
 
   /*

--- a/src/curtain-accessory.ts
+++ b/src/curtain-accessory.ts
@@ -169,8 +169,6 @@ class Device {
 
 export class Curtain implements AccessoryPlugin {
   private readonly log: Logging;
-  private readonly bleMac: string;
-  private readonly scanDuration: number;
   private readonly reverseDir: boolean;
   private readonly moveTime: number;
 
@@ -181,13 +179,13 @@ export class Curtain implements AccessoryPlugin {
   private positionState = 0;
   private moveTimer!: NodeJS.Timeout;
 
+  private device: Device;
+
   // This property must be existent!!
   name: string;
 
   private readonly curtainService: Service;
   private readonly informationService: Service;
-
-  private device: Device;
 
   private currentPositionCharacteristic: Characteristic;
   private targetPositionCharacteristic: Characteristic;
@@ -196,8 +194,6 @@ export class Curtain implements AccessoryPlugin {
   constructor(hap: HAP, log: Logging, name: string, bleMac: string, scanDuration: number, reverseDir: boolean, moveTime: number, scanInterval: number) {
     this.log = log;
     this.name = name;
-    this.bleMac = bleMac;
-    this.scanDuration = scanDuration;
     this.reverseDir = reverseDir;
     this.moveTime = moveTime;
 
@@ -222,6 +218,12 @@ export class Curtain implements AccessoryPlugin {
     });
 
     this.positionState = hap.Characteristic.PositionState.STOPPED;
+
+    this.informationService = new hap.Service.AccessoryInformation()
+      .setCharacteristic(hap.Characteristic.Manufacturer, "SwitchBot")
+      .setCharacteristic(hap.Characteristic.Model, "SWITCHBOT-CURTAIN-W0701600")
+      .setCharacteristic(hap.Characteristic.SerialNumber, bleMac);
+
     this.curtainService = new hap.Service.WindowCovering(name);
 
     this.currentPositionCharacteristic = this.curtainService
@@ -295,11 +297,6 @@ export class Curtain implements AccessoryPlugin {
         log.info("The position state of Curtain was returned: " + this.positionState);
         callback(undefined, this.positionState);
       });
-
-    this.informationService = new hap.Service.AccessoryInformation()
-      .setCharacteristic(hap.Characteristic.Manufacturer, "SwitchBot")
-      .setCharacteristic(hap.Characteristic.Model, "SWITCHBOT-CURTAIN-W0701600")
-      .setCharacteristic(hap.Characteristic.SerialNumber, this.bleMac);
 
     log.info("Curtain '%s' created!", name);
   }

--- a/src/switchbot-platform.ts
+++ b/src/switchbot-platform.ts
@@ -6,7 +6,6 @@ import { AccessoryPlugin, API, HAP, Logging, PlatformConfig, StaticPlatformPlugi
 import { Bot } from "./bot-accessory";
 import { Curtain } from "./curtain-accessory";
 import { Meter } from "./meter-accessory";
-import { off } from "process";
 
 const PLATFORM_NAME = "SwitchBotPlatform";
 
@@ -75,7 +74,7 @@ class SwitchBotPlatform implements StaticPlatformPlugin {
           case "curtain":
             const reverseDir: boolean = device.reverseDir || false;
             const moveTime: number = device.moveTime || 2000;
-            deviceList.push(new Curtain(hap, this.log, device.name, device.bleMac.toLowerCase(), scanDuration, reverseDir, moveTime));
+            deviceList.push(new Curtain(hap, this.log, device.name, device.bleMac.toLowerCase(), scanDuration, reverseDir, moveTime, device.scanInterval || 60000));
             break;
           case "meter":
             let scanInterval: number = device.scanInterval || 60000;


### PR DESCRIPTION
This PR resolves #14 by setting `currentPosition` (and `targetPosition`) to the position reported by the device advertisements using timed scans (every `60s` when idle and every `0.5s` when opening/closing via HomeKit). 

